### PR TITLE
Legend width calculation fix

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -630,7 +630,7 @@ function computeLegendDimensions(gd, groups, traces) {
                 (borderwidth + offsetX),
                 (5 + borderwidth + legendItem.height / 2) + rowHeight);
 
-            opts.width += traceGap + traceWidth;
+            opts.width = Math.max(opts.width, borderwidth + offsetX + traceWidth)
             opts.height = Math.max(opts.height, legendItem.height);
 
             // keep track of tallest trace in group

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -630,7 +630,7 @@ function computeLegendDimensions(gd, groups, traces) {
                 (borderwidth + offsetX),
                 (5 + borderwidth + legendItem.height / 2) + rowHeight);
 
-            opts.width = Math.max(opts.width, borderwidth + offsetX + traceWidth)
+            opts.width = Math.max(opts.width, borderwidth + offsetX + traceWidth);
             opts.height = Math.max(opts.height, legendItem.height);
 
             // keep track of tallest trace in group


### PR DESCRIPTION
This change is very simple. Currently, the legend calculates its width by accumulating the width of the traceWidths and the gaps between them. It does not take the wrapping of the traces (when offsetX is reset to 0 and the traces start over at the left side) into account.

This change will set the legend width to be the rightmost edge of the longest line of the wrapped traces. The traceGap width is already included in the offsetX value, so all we need to add is the borderwidth and the length of the last trace.