### PR TITLE
Add Anchoroffset (Axis stacking)

### DIFF
--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -435,6 +435,16 @@ module.exports = {
             'If set to *free*, this axis\' position is determined by `position`.'
         ].join(' ')
     },
+    // anchoroffset: used to signal which axes should offset themselves from each other
+    // automatically
+    anchoroffset: {
+        valType: 'boolean',
+        role: 'info',
+        description: [
+            'If set to true and an anchor is present, the axis will be offset by any previous',
+            'axes that share the same letter axis and side.'
+        ].join(' ')
+    },
     // side: not used directly, as values depend on direction
     // values are top, bottom for x axes, and left, right for y
     side: {

--- a/src/plots/cartesian/position_defaults.js
+++ b/src/plots/cartesian/position_defaults.js
@@ -28,7 +28,12 @@ module.exports = function handlePositionDefaults(containerIn, containerOut, coer
         }
     }, 'anchor');
 
-    if(anchor === 'free') coerce('position');
+    if(anchor === 'free') {
+        coerce('position');
+    }
+    else {
+        coerce('anchoroffset');
+    }
 
     Lib.coerce(containerIn, containerOut, {
         side: {

--- a/test/image/mocks/multiple_axes_anchored.json
+++ b/test/image/mocks/multiple_axes_anchored.json
@@ -1,0 +1,192 @@
+{
+  "data": [
+    {
+      "x": [
+        1,
+        2,
+        3
+      ],
+      "y": [
+        4,
+        5,
+        6
+      ],
+      "name": "yaxis1 data",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        2,
+        3,
+        4
+      ],
+      "y": [
+        40,
+        50,
+        60
+      ],
+      "name": "yaxis2 data",
+      "yaxis": "y2",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        4,
+        5,
+        6
+      ],
+      "y": [
+        40000,
+        50000,
+        60000
+      ],
+      "name": "yaxis3 data",
+      "yaxis": "y3",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        5,
+        6,
+        7
+      ],
+      "y": [
+        400000,
+        500000,
+        600000
+      ],
+      "name": "yaxis4 data",
+      "yaxis": "y4",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        5,
+        6,
+        7
+      ],
+      "y": [
+        400000,
+        500000,
+        600000
+      ],
+      "name": "yaxis5 data",
+      "yaxis": "y4",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        5,
+        6,
+        7
+      ],
+      "y": [
+        400000,
+        500000,
+        600000
+      ],
+      "name": "yaxis6 data",
+      "yaxis": "y4",
+      "type": "scatter"
+    }
+  ],
+  "layout": {
+    "title": "multiple y-axes example",
+    "width": 800,
+    "height": 500,
+    "xaxis": {
+      "title": "This needs to be here for now",
+      "domain": [
+        0.2,
+        0.8
+      ]
+    },
+    "xaxis2": {
+      "title": "This is another one",
+      "domain": [
+        0.2,
+        0.8
+      ],
+      "overlaying": "x",
+      "anchor": "y"
+    },
+    "yaxis": {
+      "tickfont": {
+        "color": "#1f77b4"
+      },
+      "titlefont": {
+        "color": "#1f77b4"
+      },
+      "title": "yaxis title",
+      "domain": [
+        0.1,
+        1
+      ]
+    },
+    "yaxis2": {
+      "title": "yaxis2 title",
+      "titlefont": {
+        "color": "#ff7f0e"
+      },
+      "tickfont": {
+        "color": "#ff7f0e"
+      },
+      "anchor": "x",
+      "anchoroffset": true,
+      "side": "left",
+      "position": 0.15,
+      "overlaying": "y"
+    },
+    "yaxis3": {
+      "title": "yaxis3 title",
+      "titlefont": {
+        "color": "#d62728"
+      },
+      "tickfont": {
+        "color": "#d62728"
+      },
+      "anchor": "x",
+      "side": "right",
+      "overlaying": "y"
+    },
+    "yaxis4": {
+      "title": "yaxis4 title",
+      "titlefont": {
+        "color": "#9467bd"
+      },
+      "tickfont": {
+        "color": "#9467bd"
+      },
+      "anchor": "x",
+      "side": "right",
+      "position": 0.85,
+      "overlaying": "y"
+    },
+    "yaxis5": {
+      "title": "yaxis5 title",
+      "titlefont": {
+        "color": "#94a7bd"
+      },
+      "tickfont": {
+        "color": "#94a7bd"
+      },
+      "anchor": "x",
+      "side": "right",
+      "position": 0.85,
+      "overlaying": "y"
+    },
+    "yaxis6": {
+      "title": "yaxis6 title",
+      "titlefont": {
+        "color": "#94674d"
+      },
+      "tickfont": {
+        "color": "#94674d"
+      },
+      "anchor": "x",
+      "side": "left",
+      "position": 0.85,
+      "overlaying": "y"
+    }
+  }
+}

--- a/test/image/mocks/multiple_axes_anchored.json
+++ b/test/image/mocks/multiple_axes_anchored.json
@@ -95,6 +95,7 @@
     "width": 800,
     "height": 500,
     "xaxis": {
+      "anchoroffset": true,
       "title": "This needs to be here for now",
       "domain": [
         0.2,
@@ -102,6 +103,7 @@
       ]
     },
     "xaxis2": {
+      "anchoroffset": true,
       "title": "This is another one",
       "domain": [
         0.2,
@@ -111,6 +113,7 @@
       "anchor": "y"
     },
     "yaxis": {
+      "anchoroffset": true,
       "tickfont": {
         "color": "#1f77b4"
       },
@@ -146,6 +149,7 @@
         "color": "#d62728"
       },
       "anchor": "x",
+      "anchoroffset": true,
       "side": "right",
       "overlaying": "y"
     },
@@ -158,6 +162,7 @@
         "color": "#9467bd"
       },
       "anchor": "x",
+      "anchoroffset": true,
       "side": "right",
       "position": 0.85,
       "overlaying": "y"
@@ -171,6 +176,7 @@
         "color": "#94a7bd"
       },
       "anchor": "x",
+      "anchoroffset": true,
       "side": "right",
       "position": 0.85,
       "overlaying": "y"
@@ -184,6 +190,7 @@
         "color": "#94674d"
       },
       "anchor": "x",
+      "anchoroffset": true,
       "side": "left",
       "position": 0.85,
       "overlaying": "y"


### PR DESCRIPTION
This adds an option to have axes that are anchored to another axis stack next to each other based on their bounding boxes.
It includes a new layout option, anchoroffset, which if set to true will enable the feature.
This also includes a change to the bounding box calculations for axis objects, which did not used to include the title of the axis.
When axes are rendered, they are assigned an index used for determining the offsets of following axes. These are checked and recomputed on each render, buy they are cached on the axis object so that the order will be stable.