### PR TITLE
Add number formatter option

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1270,6 +1270,9 @@ function formatLinear(ax, out, hover, extraPrecision, hideexp) {
 var SIPREFIXES = ['f', 'p', 'n', 'μ', 'm', '', 'k', 'M', 'G', 'T'];
 
 function numFormat(v, ax, fmtoverride, hover) {
+    if (ax.numberformatter) {
+        return ax.numberformatter(v, ax)
+    }
         // negative?
     var isNeg = v < 0,
         // max number of digits past decimal point to show

--- a/src/plots/cartesian/axis_defaults.js
+++ b/src/plots/cartesian/axis_defaults.js
@@ -74,6 +74,10 @@ module.exports = function handleAxisDefaults(containerIn, containerOut, coerce, 
         }
     }
 
+    if(axType === 'linear' || axType === 'log') {
+        coerce('numberformatter')
+    }
+
     if(axType === 'date') {
         var handleCalendarDefaults = Registry.getComponentMethod('calendars', 'handleDefaults');
         handleCalendarDefaults(containerIn, containerOut, 'calendar', options.calendar);

--- a/src/plots/cartesian/layout_attributes.js
+++ b/src/plots/cartesian/layout_attributes.js
@@ -354,6 +354,15 @@ module.exports = {
             '*%H~%M~%S.%2f* would display *09~15~23.46*'
         ].join(' ')
     },
+    numberformatter: {
+        valType: 'any',
+        dflt: null,
+        role: 'style',
+        description: [
+            'Supply a custom formatting function for numeric tick labels on',
+            'linear and log plots'
+        ].join(' ')
+    },
     // lines and grids
     showline: {
         valType: 'boolean',


### PR DESCRIPTION
Adds a number formatter option to axis configuration. This should be a
function that accepts a value and returns a string for use in tick
labels and tooltips.