### PR TITLE
Axis margin push

### DIFF
--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -18,6 +18,7 @@ var svgTextUtils = require('../../lib/svg_text_utils');
 var Titles = require('../../components/titles');
 var Color = require('../../components/color');
 var Drawing = require('../../components/drawing');
+var Plots = require('../../plots/plots');
 
 var constants = require('../../constants/numerical');
 var FP_SAFE = constants.FP_SAFE;
@@ -1886,10 +1887,28 @@ axes.doTicks = function(gd, axid, skipTitle) {
             ax._boundingBox = comboBox;
         }
 
+        function expandMargins() {
+            var bBox = ax._boundingBox
+            var halfWidth = bBox.width * 0.5
+            var halfHeight = bBox.height * 0.5
+            var x = (bBox.left + halfWidth - fullLayout._size.l) / fullLayout._size.w
+            var y = (fullLayout._size.h + fullLayout._size.t - bBox.top - halfHeight) / fullLayout._size.h
+            console.log(fullLayout._size.h, fullLayout._size.t,  bBox.top, halfHeight)
+            Plots.autoMargin(gd, 'axisLabels' + axid, {
+                x: x,
+                y: y,
+                l: halfWidth,
+                r: halfWidth,
+                b: halfHeight,
+                t: halfHeight,
+            });
+        }
+
         var done = Lib.syncOrAsync([
             allLabelsReady,
             fixLabelOverlaps,
-            calcBoundingBox
+            calcBoundingBox,
+            expandMargins
         ]);
         if(done && done.then) gd._promises.push(done);
         return done;

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1891,17 +1891,42 @@ axes.doTicks = function(gd, axid, skipTitle) {
             var bBox = ax._boundingBox
             var halfWidth = bBox.width * 0.5
             var halfHeight = bBox.height * 0.5
-            var x = (bBox.left + halfWidth - fullLayout._size.l) / fullLayout._size.w
-            var y = (fullLayout._size.h + fullLayout._size.t - bBox.top - halfHeight) / fullLayout._size.h
-            console.log(fullLayout._size.h, fullLayout._size.t,  bBox.top, halfHeight)
-            Plots.autoMargin(gd, 'axisLabels' + axid, {
-                x: x,
-                y: y,
+            var margins = {
+                x: 0.5,
+                y: 0.5,
                 l: halfWidth,
                 r: halfWidth,
                 b: halfHeight,
-                t: halfHeight,
-            });
+                t: halfHeight
+            };
+            // For some strange reason, the four sides of the plot need slightly different margin calculations
+            // to be stable.
+            if (ax.anchor == 'x') {
+                if (ax.side == 'right') {
+                    margins.x = 1 + (ax._anchorOffset / fullLayout._size.w);
+                    margins.l = 0
+                    margins.r = bBox.width
+                }
+                else {
+                    margins.x = (bBox.left + halfWidth - fullLayout._size.l) / fullLayout._size.w
+                    margins.l = halfWidth;
+                    margins.r = halfWidth;
+                }
+            }
+            else if (ax.anchor == 'y') {
+                if (ax.side == 'top') {
+                    margins.y = 1 + (ax._anchorOffset / fullLayout._size.h)
+                    margins.t = bBox.height
+                    margins.b = 0
+                }
+                else {
+                    margins.y = -(ax._anchorOffset / fullLayout._size.h)
+                    margins.t = 0
+                    margins.b = bBox.height
+                }
+            }
+
+            Plots.autoMargin(gd, 'axisLabels' + axid, margins);
         }
 
         var done = Lib.syncOrAsync([

--- a/src/plots/cartesian/axes.js
+++ b/src/plots/cartesian/axes.js
@@ -1899,8 +1899,6 @@ axes.doTicks = function(gd, axid, skipTitle) {
                 b: halfHeight,
                 t: halfHeight
             };
-            // For some strange reason, the four sides of the plot need slightly different margin calculations
-            // to be stable.
             if (ax.anchor == 'x') {
                 if (ax.side == 'right') {
                     margins.x = 1 + (ax._anchorOffset / fullLayout._size.w);
@@ -1908,9 +1906,9 @@ axes.doTicks = function(gd, axid, skipTitle) {
                     margins.r = bBox.width
                 }
                 else {
-                    margins.x = (bBox.left + halfWidth - fullLayout._size.l) / fullLayout._size.w
-                    margins.l = halfWidth;
-                    margins.r = halfWidth;
+                    margins.x = ax._anchorOffset / fullLayout._size.w
+                    margins.l = bBox.width;
+                    margins.r = 0;
                 }
             }
             else if (ax.anchor == 'y') {

--- a/test/image/mocks/multiple_axes_anchored.json
+++ b/test/image/mocks/multiple_axes_anchored.json
@@ -92,8 +92,13 @@
   ],
   "layout": {
     "title": "multiple y-axes example",
-    "width": 800,
-    "height": 500,
+    "width": 1200,
+    "height": 800,
+    "legend": {
+        "orientation": "h",
+        "y": 0,
+        "yanchor": "top"
+    },
     "xaxis": {
       "anchoroffset": true,
       "title": "This needs to be here for now"
@@ -102,10 +107,29 @@
       "anchoroffset": true,
       "title": "This is another one",
       "overlaying": "x",
-      "anchor": "y"
+      "anchor": "y",
+      "titlefont": {
+        "size": 30
+      },
+      "tickfont": {
+        "size": 30
+      }
+    },
+    "xaxis3": {
+      "anchoroffset": true,
+      "title": "This is another",
+      "overlaying": "x",
+      "anchor": "y",
+      "titlefont": {
+        "size": 30
+      },
+      "tickfont": {
+        "size": 30
+      }
     },
     "yaxis": {
       "anchoroffset": true,
+      "anchor": "x",
       "tickfont": {
         "color": "#1f77b4"
       },
@@ -130,10 +154,12 @@
     "yaxis3": {
       "title": "yaxis3 title",
       "titlefont": {
-        "color": "#d62728"
+        "color": "#d62728",
+        "size": 27
       },
       "tickfont": {
-        "color": "#d62728"
+        "color": "#d62728",
+        "size": 27
       },
       "anchor": "x",
       "anchoroffset": true,
@@ -146,7 +172,8 @@
         "color": "#9467bd"
       },
       "tickfont": {
-        "color": "#9467bd"
+        "color": "#9467bd",
+        "size": 20
       },
       "anchor": "x",
       "anchoroffset": true,

--- a/test/image/mocks/multiple_axes_anchored.json
+++ b/test/image/mocks/multiple_axes_anchored.json
@@ -125,7 +125,6 @@
       "anchor": "x",
       "anchoroffset": true,
       "side": "left",
-      "position": 0.15,
       "overlaying": "y"
     },
     "yaxis3": {
@@ -152,7 +151,6 @@
       "anchor": "x",
       "anchoroffset": true,
       "side": "right",
-      "position": 0.85,
       "overlaying": "y"
     },
     "yaxis5": {
@@ -166,7 +164,6 @@
       "anchor": "x",
       "anchoroffset": true,
       "side": "right",
-      "position": 0.85,
       "overlaying": "y"
     },
     "yaxis6": {
@@ -180,7 +177,6 @@
       "anchor": "x",
       "anchoroffset": true,
       "side": "left",
-      "position": 0.85,
       "overlaying": "y"
     }
   }

--- a/test/image/mocks/multiple_axes_anchored.json
+++ b/test/image/mocks/multiple_axes_anchored.json
@@ -96,19 +96,11 @@
     "height": 500,
     "xaxis": {
       "anchoroffset": true,
-      "title": "This needs to be here for now",
-      "domain": [
-        0.2,
-        0.8
-      ]
+      "title": "This needs to be here for now"
     },
     "xaxis2": {
       "anchoroffset": true,
       "title": "This is another one",
-      "domain": [
-        0.2,
-        0.8
-      ],
       "overlaying": "x",
       "anchor": "y"
     },
@@ -120,11 +112,7 @@
       "titlefont": {
         "color": "#1f77b4"
       },
-      "title": "yaxis title",
-      "domain": [
-        0.1,
-        1
-      ]
+      "title": "yaxis title"
     },
     "yaxis2": {
       "title": "yaxis2 title",


### PR DESCRIPTION
This causes anchored axes to push out margins so that the plot will automatically make space for them. It also causes the legend to shift over so that it doesn’t overlap the axis labels.